### PR TITLE
Test clean data

### DIFF
--- a/scripts/2_clean_data.py
+++ b/scripts/2_clean_data.py
@@ -90,7 +90,7 @@ def clean_and_split_data(df, output_file, output_dir=None):
         test_output_path='data/processed/scaled_test.csv'
     )
     
-    return clean_train_df
+    return clean_train_df, clean_test_df
 
 @click.command()
 @click.option('--input-file', '-i',

--- a/scripts/2_clean_data.py
+++ b/scripts/2_clean_data.py
@@ -2,9 +2,6 @@ import os
 import click
 import pandas as pd
 from sklearn.model_selection import train_test_split
-from sklearn.compose import make_column_transformer, make_column_selector
-from sklearn.preprocessing import StandardScaler
-import pickle
 import sys
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -14,115 +11,106 @@ if project_root not in sys.path:
 
 from src.preprocessing import preprocess_data
 
+def clean_and_split_data(df, output_file, output_dir=None):
+    """
+    Core logic function to clean, split, and trigger preprocessing.
+    Refactored for testing purposes.
+    """
+    if not isinstance(df, pd.DataFrame):
+        raise TypeError("Input 'df' must be a pandas DataFrame")
+
+    # Validation: Ensure no "Unnamed" index column exists
+    if any(df.columns.str.contains("Unnamed")):
+        raise AssertionError("Error: Unnamed index column detected! Please check if the raw data was saved with index=False.")
+
+    # Clean Column Names
+    clean_columns = []
+    for col in df.columns:
+        if col.endswith('1'):
+            clean_name = col[:-1] + '_mean'
+        elif col.endswith('2'):
+            clean_name = col[:-1] + '_se'
+        elif col.endswith('3'):
+            clean_name = col[:-1] + '_max'
+        else:
+            clean_name = col
+        clean_columns.append(clean_name)
+    
+    df.columns = clean_columns
+    
+    # Clean Target Column ('Diagnosis')
+    if 'Diagnosis' in df.columns:
+        df['Diagnosis'] = df['Diagnosis'].map({
+            'M': 'Malignant', 'B': 'Benign'})
+    
+    # Create directory if it doesn't exist
+    target_dir = output_dir if output_dir else os.path.dirname(output_file)
+    if target_dir and not os.path.exists(target_dir):
+        os.makedirs(target_dir)
+
+    # Save cleaned full data
+    df.to_csv(output_file, index=False)
+    
+    # Split Data
+    clean_train_df, clean_test_df = train_test_split(
+        df, test_size=0.2, random_state=123, stratify=df.get('Diagnosis')
+    )
+    
+    # Save splits
+    # Note: In a real scenario you might want these paths dynamic, keeping hardcoded to match original script style
+    clean_train_df.to_csv('data/processed/clean_train.csv', index=False)
+    clean_test_df.to_csv('data/processed/clean_test.csv', index=False)
+    
+    # Define features
+    numeric_feats = [
+        'radius_mean', 'texture_mean', 'smoothness_mean', 'compactness_mean',
+        'concavity_mean', 'concave_points_mean', 'symmetry_mean', 'fractal_dimension_mean',
+        'radius_se', 'texture_se', 'smoothness_se', 'compactness_se', 'concavity_se',
+        'concave_points_se', 'symmetry_se', 'fractal_dimension_se',
+        'radius_max', 'texture_max', 'smoothness_max', 'compactness_max',
+        'concavity_max', 'concave_points_max', 'symmetry_max', 'fractal_dimension_max'
+    ]
+
+    drop_feats = [
+        'perimeter_mean', 'area_mean',
+        'perimeter_se', 'area_se',
+        'texture_se', 'smoothness_se', 'symmetry_se',
+        'perimeter_max', 'area_max'
+    ]
+
+    # Call Preprocessing
+    preprocess_data(
+        train_df=clean_train_df,
+        test_df=clean_test_df,
+        numeric_features=numeric_feats,
+        drop_features=drop_feats,
+        output_pickle_path="results/models/preprocessor.pickle",
+        save_transformed_csv=True,
+        train_output_path='data/processed/scaled_train.csv',
+        test_output_path='data/processed/scaled_test.csv'
+    )
+    
+    return clean_train_df
+
 @click.command()
 @click.option('--input-file', '-i',
               default='data/raw/breast_cancer_raw.csv',
-              type=click.Path(exists=True),
               help='Path to the raw input CSV file.')
 @click.option('--output-file', '-o',
               default='data/processed/breast_cancer_cleaned.csv',
               type=str,
               help='Path/filename where the cleaned data will be saved.')
 def main(input_file, output_file):
-    """
-    Reads raw data, performs cleaning and preprocessing, and saves the result.
-
-    This script loads the raw CSV, checks for formatting issues ,
-    renames columns to be more descriptive.
-    Converting suffix 1/2/3 to _mean/_se/_max,
-    and maps the target variable 'Diagnosis' to full labels.
-
-    Parameters
-    ----------
-    input_file : str
-        The path to the raw data file.
-        Default: data/raw/breast_cancer_raw.csv
-    output_file : str
-        The path where the processed data should be saved.
-        Default: data/processed/breast_cancer_cleaned.csv
-    """
-    
     click.echo(f"Reading data from {input_file}...")
 
     try:
         # Read the data
         df = pd.read_csv(input_file)
         
-        # Validation: Ensure no "Unnamed" index column exists
-        if any(df.columns.str.contains("Unnamed")):
-            raise AssertionError("Error: Unnamed index column detected! Please check if the raw data was saved with index=False.")
-
-        # Clean Column Names
-        clean_columns = []
-        for col in df.columns:
-            if col.endswith('1'):
-                clean_name = col[:-1] + '_mean'
-            elif col.endswith('2'):
-                clean_name = col[:-1] + '_se'
-            elif col.endswith('3'):
-                clean_name = col[:-1] + '_max'
-            else:
-                clean_name = col
-            clean_columns.append(clean_name)
+        # Call the core logic function
+        clean_and_split_data(df, output_file)
         
-        df.columns = clean_columns
-        
-        # Clean Target Column ('Diagnosis')
-        if 'Diagnosis' in df.columns:
-            df['Diagnosis'] = df['Diagnosis'].map({
-                'M': 'Malignant', 'B': 'Benign'})
-            click.echo("Target column 'Diagnosis' mapped to labels.")
-        else:
-            click.echo(click.style("Warning: 'Diagnosis' column not found.", fg='yellow'))
-
-        # Save the processed data
-        # Ensure output directory exists (data/processed/)
-        output_dir = os.path.dirname(output_file)
-        if output_dir and not os.path.exists(output_dir):
-            os.makedirs(output_dir)
-            click.echo(f"Created directory: {output_dir}")
-        
-        df.to_csv(output_file, index=False)
         click.echo(click.style(f"Successfully saved processed data to {output_file}", fg='green'))
-        
-        clean_train_df, clean_test_df = train_test_split(
-            df, test_size=0.2, random_state=123, stratify=df['Diagnosis']
-        )
-        clean_train_df.to_csv('data/processed/clean_train.csv', index=False)
-        clean_test_df.to_csv('data/processed/clean_test.csv', index=False)
-        
-        click.echo(click.style(f"Successfully saved split processed data", fg='green'))
-
-        #Preprocessing related works begins here
-        
-        numeric_feats = [
-            'radius_mean', 'texture_mean', 'smoothness_mean', 'compactness_mean',
-            'concavity_mean', 'concave_points_mean', 'symmetry_mean', 'fractal_dimension_mean',
-            'radius_se', 'texture_se', 'smoothness_se', 'compactness_se', 'concavity_se',
-            'concave_points_se', 'symmetry_se', 'fractal_dimension_se',
-            'radius_max', 'texture_max', 'smoothness_max', 'compactness_max',
-            'concavity_max', 'concave_points_max', 'symmetry_max', 'fractal_dimension_max'
-        ]
-
-        drop_feats = [
-            'perimeter_mean', 'area_mean',
-            'perimeter_se', 'area_se',
-            'texture_se', 'smoothness_se', 'symmetry_se',
-            'perimeter_max', 'area_max'
-        ]
-
-        #Using function from preprocessing.py to preprocess
-        result = preprocess_data(
-            train_df=clean_train_df,
-            test_df=clean_test_df,
-            numeric_features=numeric_feats,
-            drop_features=drop_feats,
-            output_pickle_path="results/models/preprocessor.pickle",
-            save_transformed_csv=True,
-            train_output_path='data/processed/scaled_train.csv',
-            test_output_path='data/processed/scaled_test.csv'
-        )
-        
         click.echo(click.style(f"Successfully saved scaled data and preprocessor", fg='green'))
 
     except Exception as e:

--- a/test/test_clean_data.py
+++ b/test/test_clean_data.py
@@ -1,0 +1,109 @@
+import pytest
+import pandas as pd
+import os
+import sys
+import importlib.util
+from unittest.mock import patch, MagicMock
+
+# --- Path Setup ---
+current_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(current_dir)
+if project_root not in sys.path:
+    sys.path.append(project_root)
+
+script_name = "2_clean_data"
+file_path = os.path.join(project_root, "scripts", f"{script_name}.py")
+
+# Debugging check
+if not os.path.exists(file_path):
+    raise FileNotFoundError(f"Script not found at: {file_path}")
+
+spec = importlib.util.spec_from_file_location(script_name, file_path)
+clean_data_module = importlib.util.module_from_spec(spec)
+sys.modules[script_name] = clean_data_module
+spec.loader.exec_module(clean_data_module)
+
+# Access the function
+clean_and_split_data = clean_data_module.clean_and_split_data
+
+# --- Fixtures ---
+
+@pytest.fixture
+def mock_raw_df():
+    """Create a mock raw DataFrame with original column names."""
+    # INCREASED SIZE: 20 rows to allow stratified split with test_size=0.2
+    return pd.DataFrame({
+        'radius1': [10.0] * 20,
+        'texture2': [20.0] * 20,
+        'perimeter3': [30.0] * 20,
+        'Diagnosis': ['M', 'B'] * 10
+    })
+
+# --- Test Cases ---
+
+def test_clean_data_success(mock_raw_df):
+    """
+    Test Case: Valid DataFrame input.
+    Expected: Columns renamed, target mapped, files saved, and preprocessing called.
+    """
+    with patch('os.makedirs') as mock_makedirs, \
+         patch('os.path.exists', return_value=False), \
+         patch('pandas.DataFrame.to_csv') as mock_to_csv, \
+         patch.object(clean_data_module, 'preprocess_data') as mock_preprocess:
+
+        output_file = 'data/processed/breast_cancer_cleaned.csv'
+        train_df, test_df = clean_and_split_data(mock_raw_df, output_file)
+
+        # 1. Verify Directory Creation
+        assert mock_makedirs.called
+
+        # 2. Verify File Saving (Full, Train, Test)
+        assert mock_to_csv.call_count == 3
+        
+        # 3. Verify Logic: Column Renaming
+        assert 'radius_mean' in train_df.columns
+        assert 'texture_se' in train_df.columns
+        assert 'perimeter_max' in train_df.columns
+        assert 'radius1' not in train_df.columns
+
+        # 4. Verify Logic: Target Mapping
+        assert 'Malignant' in train_df['Diagnosis'].values
+        assert 'M' not in train_df['Diagnosis'].values
+
+        # 5. Verify Preprocessing Call
+        assert mock_preprocess.called
+        _, kwargs = mock_preprocess.call_args
+        assert kwargs['save_transformed_csv'] is True
+        assert 'radius_mean' in kwargs['numeric_features']
+
+def test_unnamed_col_raises_error(mock_raw_df):
+    """
+    Test Case: DataFrame contains 'Unnamed' column (bad index save).
+    Expected: Raises AssertionError.
+    """
+    mock_raw_df['Unnamed: 0'] = [0] * 20
+    
+    with pytest.raises(AssertionError, match="Unnamed index column detected"):
+        clean_and_split_data(mock_raw_df, 'results/output.csv')
+
+def test_invalid_input_raises_error():
+    """
+    Test Case: Input is not a DataFrame.
+    Expected: Raises TypeError.
+    """
+    with pytest.raises(TypeError, match="must be a pandas DataFrame"):
+        clean_and_split_data("invalid input", 'results/output.csv')
+
+def test_existing_directory_does_not_call_makedirs(mock_raw_df):
+    """
+    Test Case: Output directory already exists.
+    Expected: os.makedirs is NOT called.
+    """
+    with patch('os.path.exists', return_value=True), \
+         patch('os.makedirs') as mock_makedirs, \
+         patch('pandas.DataFrame.to_csv'), \
+         patch.object(clean_data_module, 'preprocess_data'):
+        
+        clean_and_split_data(mock_raw_df, 'existing_folder/output.csv')
+        
+        mock_makedirs.assert_not_called()


### PR DESCRIPTION
This PR refactors the data cleaning script (scripts/2_clean_data.py) to improve modularity and testability, and adds  comprehensive unit tests to ensure robustness.

**Key Changes:**

**Refactored 2_clean_data.py:**
- Extracted the core data processing logic (renaming, mapping, splitting, preprocessing) into a reusable function clean_and_split_data.

- The script remains executable but can now be imported by test modules without running the main execution block.

- Fixed a bug where the function was missing a return statement for the split dataframes.

**Added tests/test_clean_data.py:**
- Implemented unit tests using pytest and unittest.mock.

**Added test cases for:**
- Successful execution (file creation, column renaming, target mapping).
- Error handling for invalid input types.
- Detection of "Unnamed" index columns (preventing bad data saves).
- Verification that directories are created only when needed.

Previously, the cleaning logic was tightly coupled within the main execution block, making it impossible to test in isolation. This refactor allows us to verify the data pipeline's integrity automatically without manually running the full script or relying on external files.